### PR TITLE
Load default content

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,4 +1,4 @@
-tt_content.tx_codehighlight_codesnippet = FLUIDTEMPLATE
+tt_content.tx_codehighlight_codesnippet =< lib.contentElement
 tt_content.tx_codehighlight_codesnippet {
   templateName = CodeSnippet
 


### PR DESCRIPTION
This is needed to output all content header data.

Reference: https://docs.typo3.org/c/typo3/cms-fluid-styled-content/master/en-us/AddingYourOwnContentElements/Index.html#setup-txt